### PR TITLE
Add players sitting out

### DIFF
--- a/app/Http/Controllers/EventGameController.php
+++ b/app/Http/Controllers/EventGameController.php
@@ -40,8 +40,13 @@ class EventGameController extends Controller
             'games' => $event->games()
                 ->where('round', $round)
                 ->with('players')
-                ->orderByDesc('round')
-                ->orderByDesc('court')
+                ->orderBy('court')
+                ->get(),
+            'playersSittingOut' => $event->players()
+                ->whereDoesntHave('games', function ($query) use ($event, $round) {
+                    $query->where('event_id', $event->id)->where('round', $round);
+                })
+                ->orderBy('name')
                 ->get(),
             'event' => $event,
             'round' => $round,

--- a/app/Http/Controllers/EventPlayerController.php
+++ b/app/Http/Controllers/EventPlayerController.php
@@ -62,6 +62,16 @@ class EventPlayerController extends Controller
      */
     public function destroy(Event $event, Player $player): RedirectResponse
     {
+        $hasGames = $event->games()->whereHas('players', function (Builder $query) use ($player) {
+            $query->where('players.id', $player->id);
+        })->exists();
+
+        if ($hasGames) {
+            Inertia::flash('toast', ['type' => 'error', 'message' => 'Cannot remove player with games in this event.']);
+
+            return back();
+        }
+
         $event->players()->detach($player);
 
         return back();

--- a/app/Http/Controllers/EventSettingController.php
+++ b/app/Http/Controllers/EventSettingController.php
@@ -16,7 +16,9 @@ class EventSettingController extends Controller
         return Inertia::render('events/settings/index', [
             'title' => 'Settings',
             'backUrl' => route('events.index'),
-            'event' => $event->load('players'),
+            'event' => $event->load(['players' => function ($query) {
+                $query->orderBy('name');
+            }]),
         ]);
     }
 }

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -63,7 +63,8 @@ class Game extends Model
      */
     public function gamePlayers(): HasMany
     {
-        return $this->hasMany(GamePlayer::class);
+        return $this->hasMany(GamePlayer::class)
+            ->orderBy('previous_event_rating', 'desc');
     }
 
     /**
@@ -74,6 +75,7 @@ class Game extends Model
         return $this->belongsToMany(Player::class)
             ->using(GamePlayer::class)
             ->withTrashed()
+            ->orderByPivot('previous_event_rating', 'desc')
             ->withPivot('previous_player_rating', 'previous_event_rating', 'points', 'partner_id', 'result');
     }
 }

--- a/resources/js/actions/App/Http/Controllers/EventGameController.ts
+++ b/resources/js/actions/App/Http/Controllers/EventGameController.ts
@@ -69,7 +69,7 @@ index.head = (args: { event: number | { id: number } } | [event: number | { id: 
 
 /**
 * @see \App\Http\Controllers\EventGameController::store
-* @see app/Http/Controllers/EventGameController.php:55
+* @see app/Http/Controllers/EventGameController.php:60
 * @route '/events/{event}/games'
 */
 export const store = (args: { event: number | { id: number } } | [event: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -84,7 +84,7 @@ store.definition = {
 
 /**
 * @see \App\Http\Controllers\EventGameController::store
-* @see app/Http/Controllers/EventGameController.php:55
+* @see app/Http/Controllers/EventGameController.php:60
 * @route '/events/{event}/games'
 */
 store.url = (args: { event: number | { id: number } } | [event: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -117,7 +117,7 @@ store.url = (args: { event: number | { id: number } } | [event: number | { id: n
 
 /**
 * @see \App\Http\Controllers\EventGameController::store
-* @see app/Http/Controllers/EventGameController.php:55
+* @see app/Http/Controllers/EventGameController.php:60
 * @route '/events/{event}/games'
 */
 store.post = (args: { event: number | { id: number } } | [event: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -127,7 +127,7 @@ store.post = (args: { event: number | { id: number } } | [event: number | { id: 
 
 /**
 * @see \App\Http\Controllers\EventGameController::update
-* @see app/Http/Controllers/EventGameController.php:95
+* @see app/Http/Controllers/EventGameController.php:100
 * @route '/events/{event}/games/{game}'
 */
 export const update = (args: { event: number | { id: number }, game: number | { id: number } } | [event: number | { id: number }, game: number | { id: number } ], options?: RouteQueryOptions): RouteDefinition<'put'> => ({
@@ -142,7 +142,7 @@ update.definition = {
 
 /**
 * @see \App\Http\Controllers\EventGameController::update
-* @see app/Http/Controllers/EventGameController.php:95
+* @see app/Http/Controllers/EventGameController.php:100
 * @route '/events/{event}/games/{game}'
 */
 update.url = (args: { event: number | { id: number }, game: number | { id: number } } | [event: number | { id: number }, game: number | { id: number } ], options?: RouteQueryOptions) => {
@@ -172,7 +172,7 @@ update.url = (args: { event: number | { id: number }, game: number | { id: numbe
 
 /**
 * @see \App\Http\Controllers\EventGameController::update
-* @see app/Http/Controllers/EventGameController.php:95
+* @see app/Http/Controllers/EventGameController.php:100
 * @route '/events/{event}/games/{game}'
 */
 update.put = (args: { event: number | { id: number }, game: number | { id: number } } | [event: number | { id: number }, game: number | { id: number } ], options?: RouteQueryOptions): RouteDefinition<'put'> => ({
@@ -182,7 +182,7 @@ update.put = (args: { event: number | { id: number }, game: number | { id: numbe
 
 /**
 * @see \App\Http\Controllers\EventGameController::update
-* @see app/Http/Controllers/EventGameController.php:95
+* @see app/Http/Controllers/EventGameController.php:100
 * @route '/events/{event}/games/{game}'
 */
 update.patch = (args: { event: number | { id: number }, game: number | { id: number } } | [event: number | { id: number }, game: number | { id: number } ], options?: RouteQueryOptions): RouteDefinition<'patch'> => ({

--- a/resources/js/components/events/event-card.svelte
+++ b/resources/js/components/events/event-card.svelte
@@ -10,14 +10,16 @@
 
     const { event }: Props = $props();
 
-    const endDate = dayjs(event.ended_at).calendar(null, {
-        sameDay: "[Today]", // The same day ( Today at 2:30 AM )
-        nextDay: "[Tomorrow]", // The next day ( Tomorrow at 2:30 AM )
-        nextWeek: "dddd", // The next week ( Sunday at 2:30 AM )
-        lastDay: "[Yesterday]", // The day before ( Yesterday at 2:30 AM )
-        lastWeek: "dddd", // Last week ( Last Monday at 2:30 AM )
-        sameElse: "DD/MM/YYYY", // Everything else ( 7/10/2011 )
-    });
+    const endDate = $derived(
+        dayjs(event.ended_at).calendar(null, {
+            sameDay: "[Today]", // The same day ( Today at 2:30 AM )
+            nextDay: "[Tomorrow]", // The next day ( Tomorrow at 2:30 AM )
+            nextWeek: "dddd", // The next week ( Sunday at 2:30 AM )
+            lastDay: "[Yesterday]", // The day before ( Yesterday at 2:30 AM )
+            lastWeek: "dddd", // Last week ( Last Monday at 2:30 AM )
+            sameElse: "DD/MM/YYYY", // Everything else ( 7/10/2011 )
+        }),
+    );
 </script>
 
 <Link href={show(event)} viewTransition>

--- a/resources/js/components/games/GameCard.svelte
+++ b/resources/js/components/games/GameCard.svelte
@@ -103,10 +103,6 @@
 </div>
 
 <style>
-    .game {
-        margin-bottom: 1rem;
-    }
-
     .game :global(.game-card-content) {
         padding-inline: 1rem;
     }
@@ -129,10 +125,12 @@
 
     .team1 .player-icon {
         color: oklch(from var(--primary) 0.8 c h);
+        align-self: center;
     }
 
     .team0 .player-icon {
         color: var(--secondary);
+        align-self: center;
     }
 
     .team0 {
@@ -141,6 +139,7 @@
         overflow: hidden;
         width: 100%;
         justify-self: start;
+        align-self: center;
     }
 
     .team0.player0 {
@@ -157,6 +156,8 @@
         gap: 0.25rem;
         overflow: hidden;
         width: 100%;
+        text-align: right;
+        align-items: center;
     }
 
     .team1.player0 {

--- a/resources/js/layouts/app.svelte
+++ b/resources/js/layouts/app.svelte
@@ -152,8 +152,10 @@
         align-items: center;
         background-color: var(--top-nav-background);
         view-transition-name: header;
-        position: sticky;
+        position: fixed;
         top: 0;
+        left: 0;
+        right: 0;
         z-index: 10;
     }
 
@@ -172,6 +174,8 @@
     }
 
     .content {
+        margin-block-start: 4rem;
+        margin-block-end: 8rem;
         padding-inline: 1rem;
         padding-bottom: 1rem;
     }
@@ -186,9 +190,11 @@
         max-width: 600px;
         background-color: var(--bottom-nav-background);
         justify-content: space-around;
-        position: sticky;
+        position: fixed;
         bottom: 0;
-
+        left: 0;
+        right: 0;
+        z-index: 10;
         & :global(.navButton) {
             flex-direction: column;
             gap: 0.25rem;

--- a/resources/js/layouts/event-layout.svelte
+++ b/resources/js/layouts/event-layout.svelte
@@ -21,11 +21,11 @@
     }
     let { children, event, title }: Props = $props();
 
-    const tabRoutes: TabRoutes = {
+    const tabRoutes: TabRoutes = $derived.by(() => ({
         settings: settings.index(event).url,
         games: games.index(event).url,
         leaderboard: leaderboard.index(event).url,
-    };
+    }));
 
     const tab = $derived.by(() => {
         if ($page.url.startsWith(tabRoutes.settings)) {
@@ -53,16 +53,18 @@
         }
     };
 
-    const isEventEnded = event.ended_at !== null;
+    const isEventEnded = $derived(event.ended_at !== null);
 
-    const endDate = dayjs(event.ended_at).calendar(null, {
-        sameDay: "[Today]", // The same day ( Today at 2:30 AM )
-        nextDay: "[Tomorrow]", // The next day ( Tomorrow at 2:30 AM )
-        nextWeek: "dddd", // The next week ( Sunday at 2:30 AM )
-        lastDay: "[Yesterday]", // The day before ( Yesterday at 2:30 AM )
-        lastWeek: "dddd", // Last week ( Last Monday at 2:30 AM )
-        sameElse: "DD/MM/YYYY", // Everything else ( 7/10/2011 )
-    });
+    const endDate = $derived.by(() =>
+        dayjs(event.ended_at).calendar(null, {
+            sameDay: "[Today]", // The same day ( Today at 2:30 AM )
+            nextDay: "[Tomorrow]", // The next day ( Tomorrow at 2:30 AM )
+            nextWeek: "dddd", // The next week ( Sunday at 2:30 AM )
+            lastDay: "[Yesterday]", // The day before ( Yesterday at 2:30 AM )
+            lastWeek: "dddd", // Last week ( Last Monday at 2:30 AM )
+            sameElse: "DD/MM/YYYY", // Everything else ( 7/10/2011 )
+        }),
+    );
 
     // Keep currentTab in sync with tab
     $effect(() => {

--- a/resources/js/pages/events/games/index.svelte
+++ b/resources/js/pages/events/games/index.svelte
@@ -12,18 +12,21 @@
     import { index, store } from "@/routes/events/games";
     import { Form, type InertiaFormProps } from "@inertiajs/svelte";
     import { endEvent } from "@/actions/App/Http/Controllers/EventController";
+    import type { Player } from "@/types/Player";
 
     interface Props {
         games: Game[];
+        playersSittingOut: Player[];
         event: Event;
         title: string;
         round: number;
         maxRound: number;
     }
 
-    const { games, event, round, maxRound }: Props = $props();
+    const { games, playersSittingOut, event, round, maxRound }: Props =
+        $props();
 
-    const isEventEnded = event.ended_at !== null;
+    const isEventEnded = $derived(event.ended_at !== null);
 </script>
 
 <svelte:head>
@@ -32,23 +35,25 @@
 <div class="page">
     {#if games.length > 0}
         <div class="rounds">
-            <Button
-                variant="outline"
-                disabled={round <= 1}
-                replace
-                href={index(event, {
-                    query: {
-                        round: round - 1,
-                    },
-                })}
-                viewTransition
-            >
-                <iconify-icon
-                    icon="material-symbols:chevron-left-rounded"
-                    width="1.5rem"
-                    height="1.5rem"
-                ></iconify-icon>
-            </Button>
+            {#key round}
+                <Button
+                    variant="outline"
+                    disabled={round <= 1}
+                    replace
+                    href={index(event, {
+                        query: {
+                            round: round - 1,
+                        },
+                    })}
+                    viewTransition
+                >
+                    <iconify-icon
+                        icon="material-symbols:chevron-left-rounded"
+                        width="1.5rem"
+                        height="1.5rem"
+                    ></iconify-icon>
+                </Button>
+            {/key}
 
             <h3>
                 <iconify-icon
@@ -59,23 +64,25 @@
                 Round {round}
             </h3>
 
-            <Button
-                variant="outline"
-                disabled={round >= maxRound}
-                replace
-                href={index(event, {
-                    query: {
-                        round: round + 1,
-                    },
-                })}
-                viewTransition
-            >
-                <iconify-icon
-                    icon="material-symbols:chevron-right-rounded"
-                    width="1.5rem"
-                    height="1.5rem"
-                ></iconify-icon>
-            </Button>
+            {#key round}
+                <Button
+                    variant="outline"
+                    disabled={round >= maxRound}
+                    replace
+                    href={index(event, {
+                        query: {
+                            round: round + 1,
+                        },
+                    })}
+                    viewTransition
+                >
+                    <iconify-icon
+                        icon="material-symbols:chevron-right-rounded"
+                        width="1.5rem"
+                        height="1.5rem"
+                    ></iconify-icon>
+                </Button>
+            {/key}
         </div>
     {/if}
 
@@ -88,6 +95,23 @@
             <GameCard {game} {event} />
         {/each}
     </div>
+
+    {#if playersSittingOut.length > 0 && games.length > 0}
+        <div class="sitting-out">
+            <iconify-icon
+                class="icon"
+                icon="fa6-solid:hourglass-half"
+                width="1.5rem"
+                height="1.5rem"
+            ></iconify-icon>
+
+            <div class="players">
+                {#each playersSittingOut as player (player.id)}
+                    <p>{player.name}</p>
+                {/each}
+            </div>
+        </div>
+    {/if}
 
     {#if !isEventEnded}
         <div class="actions">
@@ -150,7 +174,36 @@
 
     .games {
         display: grid;
+        gap: 1rem;
         margin-bottom: 2rem;
+    }
+
+    .page:has(.sitting-out) .games {
+        margin-bottom: 1rem;
+    }
+
+    .sitting-out {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 0.5rem;
+        align-items: center;
+        padding-inline: 1rem;
+        margin-bottom: 2rem;
+        color: var(--muted-foreground);
+
+        & .icon {
+            align-self: center;
+        }
+
+        & .players {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+    }
+
+    .players p:not(:last-child)::after {
+        content: ",";
     }
 
     h3 {

--- a/resources/js/routes/events/games/index.ts
+++ b/resources/js/routes/events/games/index.ts
@@ -69,7 +69,7 @@ index.head = (args: { event: number | { id: number } } | [event: number | { id: 
 
 /**
 * @see \App\Http\Controllers\EventGameController::store
-* @see app/Http/Controllers/EventGameController.php:55
+* @see app/Http/Controllers/EventGameController.php:60
 * @route '/events/{event}/games'
 */
 export const store = (args: { event: number | { id: number } } | [event: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -84,7 +84,7 @@ store.definition = {
 
 /**
 * @see \App\Http\Controllers\EventGameController::store
-* @see app/Http/Controllers/EventGameController.php:55
+* @see app/Http/Controllers/EventGameController.php:60
 * @route '/events/{event}/games'
 */
 store.url = (args: { event: number | { id: number } } | [event: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions) => {
@@ -117,7 +117,7 @@ store.url = (args: { event: number | { id: number } } | [event: number | { id: n
 
 /**
 * @see \App\Http\Controllers\EventGameController::store
-* @see app/Http/Controllers/EventGameController.php:55
+* @see app/Http/Controllers/EventGameController.php:60
 * @route '/events/{event}/games'
 */
 store.post = (args: { event: number | { id: number } } | [event: number | { id: number } ] | number | { id: number }, options?: RouteQueryOptions): RouteDefinition<'post'> => ({
@@ -127,7 +127,7 @@ store.post = (args: { event: number | { id: number } } | [event: number | { id: 
 
 /**
 * @see \App\Http\Controllers\EventGameController::update
-* @see app/Http/Controllers/EventGameController.php:95
+* @see app/Http/Controllers/EventGameController.php:100
 * @route '/events/{event}/games/{game}'
 */
 export const update = (args: { event: number | { id: number }, game: number | { id: number } } | [event: number | { id: number }, game: number | { id: number } ], options?: RouteQueryOptions): RouteDefinition<'put'> => ({
@@ -142,7 +142,7 @@ update.definition = {
 
 /**
 * @see \App\Http\Controllers\EventGameController::update
-* @see app/Http/Controllers/EventGameController.php:95
+* @see app/Http/Controllers/EventGameController.php:100
 * @route '/events/{event}/games/{game}'
 */
 update.url = (args: { event: number | { id: number }, game: number | { id: number } } | [event: number | { id: number }, game: number | { id: number } ], options?: RouteQueryOptions) => {
@@ -172,7 +172,7 @@ update.url = (args: { event: number | { id: number }, game: number | { id: numbe
 
 /**
 * @see \App\Http\Controllers\EventGameController::update
-* @see app/Http/Controllers/EventGameController.php:95
+* @see app/Http/Controllers/EventGameController.php:100
 * @route '/events/{event}/games/{game}'
 */
 update.put = (args: { event: number | { id: number }, game: number | { id: number } } | [event: number | { id: number }, game: number | { id: number } ], options?: RouteQueryOptions): RouteDefinition<'put'> => ({
@@ -182,7 +182,7 @@ update.put = (args: { event: number | { id: number }, game: number | { id: numbe
 
 /**
 * @see \App\Http\Controllers\EventGameController::update
-* @see app/Http/Controllers/EventGameController.php:95
+* @see app/Http/Controllers/EventGameController.php:100
 * @route '/events/{event}/games/{game}'
 */
 update.patch = (args: { event: number | { id: number }, game: number | { id: number } } | [event: number | { id: number }, game: number | { id: number } ], options?: RouteQueryOptions): RouteDefinition<'patch'> => ({


### PR DESCRIPTION
Order games and players within games correctly
Do not allow removing players from event if they have played a game 
Order players in settings correctly.
Fix svelte warnings by using derived
Improve rendering of player names in game card.
Change header and bottom nav to fixed to hopefully solve iOS problem where they move around when overscrolling. Fixed bug where if you clicked new round, then click back one round, you end up 2 rounds back.

Closes #106 
Closes #83 