### PR TITLE
Add player counts, and default date to create event form

### DIFF
--- a/resources/js/components/events/event-players.svelte
+++ b/resources/js/components/events/event-players.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <div class="header">
-    <h3>Players</h3>
+    <h3>Players ({players?.length})</h3>
     <Button href={eventPlayers(event.id)} viewTransition>Edit players</Button>
 </div>
 

--- a/resources/js/pages/events/create.svelte
+++ b/resources/js/pages/events/create.svelte
@@ -6,6 +6,7 @@
     import { Form, type InertiaFormProps } from "@inertiajs/svelte";
     import * as ButtonGroup from "@/lib/components/ui/button-group";
     import EventPointsEdit from "@/components/events/event-points-edit.svelte";
+    import dayjs from "dayjs";
 
     type FormFields = {
         court_count: number;
@@ -16,6 +17,8 @@
 
     let courtCount = 3;
     let gamePoints = 16;
+    let startAtDate = dayjs().format("YYYY-MM-DD");
+    let startAtTime = "17:30";
 
     function decrementCourtCount() {
         if (courtCount > 1) {
@@ -50,12 +53,13 @@
                     <Input
                         type="date"
                         name="starts_at_date"
+                        bind:value={startAtDate}
                         aria-invalid={!!errors.starts_at_date}
                     />
                     <Input
                         type="time"
                         name="starts_at_time"
-                        value="20:30"
+                        bind:value={startAtTime}
                         aria-invalid={!!errors.starts_at_time}
                     />
                 </div>

--- a/resources/js/pages/events/players/index.svelte
+++ b/resources/js/pages/events/players/index.svelte
@@ -60,7 +60,7 @@
 </svelte:head>
 
 <div class="page">
-    <h2>Enrolled players</h2>
+    <h2>Enrolled players ({eventPlayers.length})</h2>
     <div class="players">
         {#each eventPlayers as player (`enrolled-${player.id}`)}
             <div class="player" transition:fade={{ duration: 150 }}>


### PR DESCRIPTION
In form to create a new event, todays date is now default, and time 17:30 is now default.

In event settings, there is now a player count next to the "Players" heading. Also inside Edit players for the event, there is player count next to heading "Enrolled players".

Closes #112 
Closes #111 